### PR TITLE
Drop elasticsearch-php 1.x support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "php": ">=5.5.9",
         "broadway/broadway": "^1.0@dev",
-        "elasticsearch/elasticsearch": "~1.0|^2.0"
+        "elasticsearch/elasticsearch": "^2.0"
     },
     "authors": [
       {

--- a/src/ElasticSearchClientFactory.php
+++ b/src/ElasticSearchClientFactory.php
@@ -12,6 +12,7 @@
 namespace Broadway\ReadModel\ElasticSearch;
 
 use Elasticsearch\Client;
+use Elasticsearch\ClientBuilder;
 
 class ElasticSearchClientFactory
 {
@@ -22,10 +23,6 @@ class ElasticSearchClientFactory
      */
     public function create(array $config)
     {
-        if (class_exists('\Elasticsearch\ClientBuilder')) {
-            return \Elasticsearch\ClientBuilder::fromConfig($config);
-        }
-
-        return new Client($config);
+        return ClientBuilder::fromConfig($config);
     }
 }

--- a/test/ElasticSearchRepositoryTest.php
+++ b/test/ElasticSearchRepositoryTest.php
@@ -96,8 +96,6 @@ class ElasticSearchRepositoryTest extends RepositoryTestCase
 
     private function createClient()
     {
-        $clientFactory = new ElasticSearchClientFactory();
-
-        return $clientFactory->create(['hosts' => ['localhost:9200']]);
+        return (new ElasticSearchClientFactory())->create(['hosts' => ['localhost:9200']]);
     }
 }


### PR DESCRIPTION
This does not drop support for Elasticsearch 1.0 server, just for the elastic/elasticsearch-php 1.x branch.

As stated in https://github.com/elastic/elasticsearch-php#version-matrix: "If you are using Elasticsearch 1.x or 2.x, prefer using the Elasticsearch-PHP 2.0 branch. The 1.0 branch is compatible however."